### PR TITLE
MTV-1988: Knip - Remove unused export types

### DIFF
--- a/packages/forklift-console-plugin/src/components/ConsoleTimestamp/ConsoleTimestamp.tsx
+++ b/packages/forklift-console-plugin/src/components/ConsoleTimestamp/ConsoleTimestamp.tsx
@@ -13,7 +13,7 @@ import { GlobeAmericasIcon } from '@patternfly/react-icons';
  */
 import './ConsoleTimestamp.style.css';
 
-export type TimestampProps = {
+type TimestampProps = {
   timestamp: string | number | Date;
   className?: string;
 };

--- a/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
+++ b/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
@@ -19,7 +19,7 @@ import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 /**
  * Props for the FilterableSelect component.
  */
-export interface FilterableSelectProps {
+interface FilterableSelectProps {
   /** Array of options to display in the select dropdown */
   selectOptions: SelectOptionProps[];
   /** The currently selected value */

--- a/packages/forklift-console-plugin/src/components/InputList/InputList.tsx
+++ b/packages/forklift-console-plugin/src/components/InputList/InputList.tsx
@@ -14,7 +14,7 @@ import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import './InputList.style.css';
 
-export type InputListRow<T> = React.FC<{ value: T; onChange: (value: T) => void }>;
+type InputListRow<T> = React.FC<{ value: T; onChange: (value: T) => void }>;
 
 /**
  * Props for InputList component.

--- a/packages/forklift-console-plugin/src/components/actions/DropdownItemLink.tsx
+++ b/packages/forklift-console-plugin/src/components/actions/DropdownItemLink.tsx
@@ -30,7 +30,7 @@ export const DropdownItemLink = ({
   );
 };
 
-export type DropdownItemLinkProps = {
+type DropdownItemLinkProps = {
   key: string;
   value: number;
   href: string;

--- a/packages/forklift-console-plugin/src/components/cells/StatusCell.tsx
+++ b/packages/forklift-console-plugin/src/components/cells/StatusCell.tsx
@@ -6,7 +6,7 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { TextWithIcon } from './TextWithIcon';
 import { categoryIcons } from './utils';
 
-export interface StatusCellProps {
+interface StatusCellProps {
   label: string;
   conditions: { type?: string; message?: string; category?: string; status?: string }[];
   icon: React.ReactNode;

--- a/packages/forklift-console-plugin/src/components/cells/TextWithIcon.tsx
+++ b/packages/forklift-console-plugin/src/components/cells/TextWithIcon.tsx
@@ -3,7 +3,7 @@ import Linkify from 'react-linkify';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-export type TextWithIconProps = {
+type TextWithIconProps = {
   label: string;
   icon: React.ReactNode;
   className?: string;

--- a/packages/forklift-console-plugin/src/components/empty-states/ForkliftEmptyState.tsx
+++ b/packages/forklift-console-plugin/src/components/empty-states/ForkliftEmptyState.tsx
@@ -10,7 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-export type EmptyStateProps = {
+type EmptyStateProps = {
   icon: React.ComponentType;
   title: React.ReactNode;
   textContent: React.ReactNode;

--- a/packages/forklift-console-plugin/src/components/headers/SectionHeading.tsx
+++ b/packages/forklift-console-plugin/src/components/headers/SectionHeading.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 
-export interface SectionHeadingProps {
+interface SectionHeadingProps {
   text: ReactNode;
   className?: string;
   id?: string;

--- a/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
+++ b/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
@@ -4,7 +4,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import { ManageColumnsModal, ManageColumnsToolbarItem } from '@kubev2v/common';
 import { ResourceField } from '@kubev2v/common';
 
-export interface ManageColumnsToolbarProps {
+interface ManageColumnsToolbarProps {
   /** Read only. State maintained by parent component. */
   resourceFields: ResourceField[];
   /** Read only. The defaults used for initialization.*/

--- a/packages/forklift-console-plugin/src/components/page/StandardPageWithSelection.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPageWithSelection.tsx
@@ -77,7 +77,7 @@ export function withHeaderSelection<T>({
   return Enhanced;
 }
 
-export interface IdBasedSelectionProps<T> {
+interface IdBasedSelectionProps<T> {
   /**
    * @returns string that can be used as an unique identifier
    */

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/actions/NetworkMapActionsDropdown.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/actions/NetworkMapActionsDropdown.tsx
@@ -72,6 +72,6 @@ export const NetworkMapActionsDropdown: FC<NetworkMapActionsDropdownProps> = (pr
   </ModalHOC>
 );
 
-export interface NetworkMapActionsDropdownProps extends CellProps {
+interface NetworkMapActionsDropdownProps extends CellProps {
   isKebab?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ConditionsSection/ConditionsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ConditionsSection/ConditionsSection.tsx
@@ -70,6 +70,6 @@ export const ConditionsSection: React.FC<ConditionsSectionProps> = ({ conditions
  * @typedef {Object} ConditionsProps
  * @property {K8sResourceCondition[]} conditions - The conditions to be displayed.
  */
-export type ConditionsSectionProps = {
+type ConditionsSectionProps = {
   conditions: K8sResourceCondition[];
 };

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/DetailsSection/DetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/DetailsSection/DetailsSection.tsx
@@ -17,7 +17,7 @@ export const DetailsSection: React.FC<DetailsSectionProps> = (props) => (
   </ModalHOC>
 );
 
-export type DetailsSectionProps = {
+type DetailsSectionProps = {
   obj: V1beta1NetworkMap;
 };
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -218,7 +218,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
   );
 };
 
-export type MapsSectionProps = {
+type MapsSectionProps = {
   obj: V1beta1NetworkMap;
 };
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/components/MapsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/components/MapsEdit.tsx
@@ -83,7 +83,7 @@ export const MapsEdit: React.FC<MapsEditProps> = ({
   }
 };
 
-export type MapsEditProps = {
+type MapsEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
   onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/state/reducer.ts
@@ -8,7 +8,7 @@ export interface MapsSectionState {
   updating: boolean;
 }
 
-export type MapsAction =
+type MapsAction =
   | { type: 'SET_MAP'; payload: V1beta1NetworkMapSpecMap[] }
   | { type: 'SET_UPDATING'; payload: boolean }
   | { type: 'INIT'; payload: V1beta1NetworkMap };

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -129,6 +129,6 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
   );
 };
 
-export type ProvidersSectionProps = {
+type ProvidersSectionProps = {
   obj: V1beta1NetworkMap;
 };

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -82,7 +82,7 @@ const ProviderOption = (provider, index) => (
   />
 );
 
-export type ProvidersEditProps = {
+type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
   onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/state/reducer.ts
@@ -10,7 +10,7 @@ export interface ProvidersSectionState {
   updating: boolean;
 }
 
-export type ProvidersAction =
+type ProvidersAction =
   | { type: 'SET_SOURCE_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_TARGET_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_SOURCE_PROVIDER_MODE'; payload: 'view' | 'edit' }

--- a/packages/forklift-console-plugin/src/modules/Overview/hooks/useMigrationCounts.ts
+++ b/packages/forklift-console-plugin/src/modules/Overview/hooks/useMigrationCounts.ts
@@ -5,9 +5,9 @@ import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getMigrationCounts, getVmCounts } from '../utils';
 
-export type MigrationCounts = { [key: string]: number };
+type MigrationCounts = { [key: string]: number };
 
-export interface MigrationCountsHookResponse {
+interface MigrationCountsHookResponse {
   count: MigrationCounts;
   vmCount: MigrationCounts;
   loaded: boolean;

--- a/packages/forklift-console-plugin/src/modules/Overview/utils/helpers/OverviewUserSettings.ts
+++ b/packages/forklift-console-plugin/src/modules/Overview/utils/helpers/OverviewUserSettings.ts
@@ -1,6 +1,6 @@
 import { loadFromLocalStorage, removeFromLocalStorage, saveToLocalStorage } from '@kubev2v/common';
 
-export interface OverviewUserSettings {
+interface OverviewUserSettings {
   welcome?: WelcomeSettings;
 }
 

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/PodsTable.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/PodsTable.tsx
@@ -87,7 +87,7 @@ const getStatusLabel = (phase: string) => {
   );
 };
 
-export type PodsTableProps = {
+type PodsTableProps = {
   pods: IoK8sApiCoreV1Pod[];
   showOwner?: boolean;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdown.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdown.tsx
@@ -61,6 +61,6 @@ export const PlanActionsDropdown: React.FC<PlanActionsDropdownProps> = (props) =
   </ModalHOC>
 );
 
-export interface PlanActionsDropdownProps extends CellProps {
+interface PlanActionsDropdownProps extends CellProps {
   isKebab?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ChipsToolbarProviders.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ChipsToolbarProviders.tsx
@@ -4,7 +4,7 @@ import { Chip, ChipGroup, Toolbar, ToolbarContent, ToolbarItem } from '@patternf
 
 import { PlanCreatePageState } from '../states';
 
-export interface ChipsToolbarProvidersProps {
+interface ChipsToolbarProvidersProps {
   filterState: PlanCreatePageState;
   filterDispatch: React.Dispatch<{
     type: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/FiltersToolbarProviders.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/FiltersToolbarProviders.tsx
@@ -7,7 +7,7 @@ import { PlanCreatePageState } from '../states';
 import SearchInputProvider from './SearchInputProvider';
 import SelectProvider from './SelectProvider';
 
-export interface FiltersToolbarProvidersProps {
+interface FiltersToolbarProvidersProps {
   filterState: PlanCreatePageState;
   filterDispatch: React.Dispatch<{
     type: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/PlanCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/PlanCreateForm.tsx
@@ -33,7 +33,7 @@ import { FiltersToolbarProviders } from './FiltersToolbarProviders';
 import { PlanNameTextField } from './PlanNameTextField';
 import { ProviderCardEmptyState } from './ProvidersEmptyState';
 
-export type PlanCreateFormProps = {
+type PlanCreateFormProps = {
   providers: V1beta1Provider[];
   filterState: PlanCreatePageState;
   state: CreateVmMigrationPageState;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProviderCardContent.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProviderCardContent.tsx
@@ -26,7 +26,7 @@ export const ProviderCardContent: React.FC<ProviderCardContentProps> = ({
   );
 };
 
-export type ProviderCardContentProps = {
+type ProviderCardContentProps = {
   provider: V1beta1Provider;
   typeLabel?: string;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SearchInputProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SearchInputProvider.tsx
@@ -5,7 +5,7 @@ import { SearchInput } from '@patternfly/react-core';
 
 import { PlanCreatePageState } from '../states';
 
-export interface SearchInputProviderProps {
+interface SearchInputProviderProps {
   filterState: PlanCreatePageState;
   filterDispatch: React.Dispatch<{
     type: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SelectProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SelectProvider.tsx
@@ -20,7 +20,7 @@ import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import providerTypes from '../constanats/providerTypes';
 import { PlanCreatePageState } from '../states';
 
-export interface SelectProviderProps {
+interface SelectProviderProps {
   filterState: PlanCreatePageState;
   filterDispatch: Dispatch<{
     type: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/providerCardTitle.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/providerCardTitle.tsx
@@ -15,6 +15,6 @@ export const ProviderCardTitle: React.FC<ProviderCardTitleProps> = ({ provider }
   );
 };
 
-export type ProviderCardTitleProps = {
+type ProviderCardTitleProps = {
   provider: V1beta1Provider;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/MemoizedProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/MemoizedProviderVirtualMachinesList.tsx
@@ -3,7 +3,7 @@ import { VmData } from 'src/modules/Providers/views';
 
 import { ProviderVirtualMachinesList } from '../../components/ProvidersVirtualMachinesList';
 
-export interface ProviderVirtualMachinesListProps {
+interface ProviderVirtualMachinesListProps {
   title: string;
   name: string;
   namespace: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ConditionsSection/ConditionsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ConditionsSection/ConditionsSection.tsx
@@ -70,6 +70,6 @@ export const ConditionsSection: React.FC<ConditionsSectionProps> = ({ conditions
  * @typedef {Object} ConditionsProps
  * @property {K8sResourceCondition[]} conditions - The conditions to be displayed.
  */
-export type ConditionsSectionProps = {
+type ConditionsSectionProps = {
   conditions: K8sResourceCondition[];
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
@@ -11,7 +11,7 @@ import {
   StatusDetailsItem,
 } from './components';
 
-export type DetailsSectionProps = {
+type DetailsSectionProps = {
   obj: V1beta1Plan;
 };
 

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MigrationsSection/MigrationsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MigrationsSection/MigrationsSection.tsx
@@ -26,6 +26,6 @@ export const MigrationsSection: React.FC<MigrationsSectionProps> = ({ obj }) => 
   );
 };
 
-export type MigrationsSectionProps = {
+type MigrationsSectionProps = {
   obj: V1beta1Plan;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MigrationsSection/components/MigrationsTable.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MigrationsSection/components/MigrationsTable.tsx
@@ -118,7 +118,7 @@ const sortMigrationsByStartedAtDate = (migrations: V1beta1Migration[]) => {
   });
 };
 
-export type MigrationTableProps = {
+type MigrationTableProps = {
   migrations: V1beta1Migration[];
   showOwner?: boolean;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -72,6 +72,6 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
   );
 };
 
-export type ProvidersSectionProps = {
+type ProvidersSectionProps = {
   obj: V1beta1Plan;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -82,7 +82,7 @@ const ProviderOption = (provider, index) => (
   />
 );
 
-export type ProvidersEditProps = {
+type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
   onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/state/reducer.ts
@@ -10,7 +10,7 @@ export interface ProvidersSectionState {
   updating: boolean;
 }
 
-export type ProvidersAction =
+type ProvidersAction =
   | { type: 'SET_SOURCE_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_TARGET_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_SOURCE_PROVIDER_MODE'; payload: 'view' | 'edit' }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
@@ -26,7 +26,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = (props) => (
   </ModalHOC>
 );
 
-export type SettingsSectionProps = {
+type SettingsSectionProps = {
   obj: V1beta1Plan;
   permissions: ProvidersPermissionStatus;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
@@ -42,7 +42,7 @@ const EditPassphraseFactory: (initialValue: string) => ModalInputComponentType =
   return SecretRenderer;
 };
 
-export type EditLUKSEncryptionPasswordsProps = Modify<
+type EditLUKSEncryptionPasswordsProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
@@ -78,7 +78,7 @@ const EditPlanPreserveClusterCpuModel_: React.FC<EditPlanPreserveClusterCpuModel
   );
 };
 
-export type EditPlanPreserveClusterCpuModelProps = Modify<
+type EditPlanPreserveClusterCpuModelProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
@@ -76,7 +76,7 @@ const EditPlanPreserveStaticIPs_: React.FC<EditPlanPreserveStaticIPsProps> = (pr
   );
 };
 
-export type EditPlanPreserveStaticIPsProps = Modify<
+type EditPlanPreserveStaticIPsProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanTargetNamespace/EditPlanTargetNamespace.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanTargetNamespace/EditPlanTargetNamespace.tsx
@@ -99,7 +99,7 @@ const EditPlanTargetNamespace_: React.FC<EditPlanTargetNamespaceProps> = (props)
   );
 };
 
-export type EditPlanTargetNamespaceProps = Modify<
+type EditPlanTargetNamespaceProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanTransferNetwork/EditPlanTransferNetwork.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanTransferNetwork/EditPlanTransferNetwork.tsx
@@ -168,7 +168,7 @@ function getNetworkName(value: unknown): string {
   return `${value?.['namespace']}/${value?.['name']}`;
 }
 
-export type EditPlanTransferNetworkProps = Modify<
+type EditPlanTransferNetworkProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanWarm/EditPlanWarm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanWarm/EditPlanWarm.tsx
@@ -80,7 +80,7 @@ const EditPlanWarm_: React.FC<EditPlanWarmProps> = (props) => {
   );
 };
 
-export type EditPlanWarmProps = Modify<
+type EditPlanWarmProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/EditRootDisk.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/EditRootDisk.tsx
@@ -106,7 +106,7 @@ export const EditRootDisk: React.FC<EditRootDiskProps> = (props) => {
   );
 };
 
-export type EditRootDiskProps = Modify<
+type EditRootDiskProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Plan;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/getRootDiskLabelByKey.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/getRootDiskLabelByKey.ts
@@ -4,7 +4,7 @@
  * @property {string} key - The key representing the disk option.
  * @property {string} description - The description of the disk option.
  */
-export type DiskOption = {
+type DiskOption = {
   key: string;
   description: string;
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/utils/types.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/utils/types.ts
@@ -3,13 +3,13 @@ import { EditModalProps } from 'src/modules/Providers';
 import { Modify, V1beta1Plan, V1beta1PlanSpec, V1beta1PlanSpecVms } from '@kubev2v/types';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
-export type PlanNameTemplates = {
+type PlanNameTemplates = {
   pvcNameTemplate?: string;
   volumeNameTemplate?: string;
   networkNameTemplate?: string;
 };
 
-export type EnhancedPlanSpecVms = V1beta1PlanSpecVms & PlanNameTemplates;
+type EnhancedPlanSpecVms = V1beta1PlanSpecVms & PlanNameTemplates;
 
 export type EnhancedPlan = V1beta1Plan & {
   spec: V1beta1PlanSpec &

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/Suspend.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/Suspend.tsx
@@ -4,7 +4,7 @@ import { Bullseye } from '@patternfly/react-core';
 
 import { Loading } from './Loading';
 
-export type SuspendProps = {
+type SuspendProps = {
   obj: object;
   loaded: boolean;
   loadError: unknown;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappings.tsx
@@ -19,7 +19,7 @@ import { Alert, PageSection } from '@patternfly/react-core';
 
 import { PlanMappingsSection } from './PlanMappingsSection';
 
-export type PlanMappingsInitSectionProps = {
+type PlanMappingsInitSectionProps = {
   plan: V1beta1Plan;
   loaded: boolean;
   loadError: unknown;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
@@ -64,7 +64,7 @@ interface PlanMappingsSectionState {
   updatedStorage: V1beta1StorageMapSpecMap[];
 }
 
-export type PlanMappingsSectionProps = {
+type PlanMappingsSectionProps = {
   plan: V1beta1Plan;
   planNetworkMaps: V1beta1NetworkMap;
   planStorageMaps: V1beta1StorageMap;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/AlignedDecimal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/AlignedDecimal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useForkliftTranslation } from 'src/utils';
 
-export type AlignedDecimalProps = {
+type AlignedDecimalProps = {
   /**
    * The number to align.
    */

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/PlanVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/PlanVirtualMachines.tsx
@@ -12,7 +12,7 @@ import { MigrationVirtualMachinesList } from './Migration';
 import { PlanVirtualMachinesList } from './Plan';
 import { PlanData } from './types';
 
-export interface PlanVirtualMachinesProps {
+interface PlanVirtualMachinesProps {
   obj: PlanData;
   ns?: string;
   name?: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/MigrationVMsCancelModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/MigrationVMsCancelModal.tsx
@@ -9,7 +9,7 @@ import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-co
 
 import './PlanVMsDeleteModal.style.css';
 
-export interface MigrationVMsCancelModalProps {
+interface MigrationVMsCancelModalProps {
   migration: V1beta1Migration;
   selected: string[];
 }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PipelineTasksModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PipelineTasksModal.tsx
@@ -7,7 +7,7 @@ import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-export interface PipelineTasksModalProps {
+interface PipelineTasksModalProps {
   name: string;
   tasks: V1beta1PlanStatusMigrationVmsPipeline[];
 }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
@@ -9,7 +9,7 @@ import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-co
 
 import './PlanVMsDeleteModal.style.css';
 
-export interface PlanVMsDeleteModalProps {
+interface PlanVMsDeleteModalProps {
   plan: V1beta1Plan;
   selected: string[];
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdown.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdown.tsx
@@ -88,6 +88,6 @@ export const ProviderActionsDropdown: React.FC<ProviderActionsDropdownProps> = (
   </ModalHOC>
 );
 
-export interface ProviderActionsDropdownProps extends CellProps {
+interface ProviderActionsDropdownProps extends CellProps {
   isKebab?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
@@ -178,7 +178,7 @@ function getNetworkName(value: string | number): string {
   return parts[parts.length - 1];
 }
 
-export type EditProviderDefaultTransferNetworkProps = Modify<
+type EditProviderDefaultTransferNetworkProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Provider;

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -12,7 +12,7 @@ import { EditModal, EditModalProps } from '../EditModal';
 import { onEmptyVddkConfirm } from './onEmptyVddkConfirm';
 import { onNoneEmptyVddkConfirm } from './onNoneEmptyVddkConfirm';
 
-export type EditProviderVDDKImageProps = Modify<
+type EditProviderVDDKImageProps = Modify<
   EditModalProps,
   {
     resource: V1beta1Provider;

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/ModalHOC/ModalHOC.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/ModalHOC/ModalHOC.tsx
@@ -62,12 +62,12 @@ export const useModal = (): ModalContextType => {
   return context;
 };
 
-export interface ModalContextType {
+interface ModalContextType {
   showModal: (modal: ReactNode) => void;
   toggleModal: () => void;
 }
 
-export interface ModalHOCProps {
+interface ModalHOCProps {
   children: ReactNode;
 }
 

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
@@ -8,7 +8,7 @@ import { FetchCertificateModal } from './FetchCertificateModal';
 
 import './CertificateUpload.style.css';
 
-export interface CertificateUploadProps extends FileUploadProps {
+interface CertificateUploadProps extends FileUploadProps {
   url?: string;
 }
 

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
@@ -205,7 +205,7 @@ export const ContentField: React.FC<{
  * @property {ReactNode | ReactNode[]} content - Array of content fields to be displayed for the details item.
  * @property {Function | Function[]} onEdit - Array of functions per content field to be called when the edit button is clicked or null if the field is non editable.
  */
-export type DetailsItemProps = {
+type DetailsItemProps = {
   title: string;
   helpContent?: ReactNode;
   showHelpIconNextToTitle?: boolean;

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/OwnerReferencesItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/OwnerReferencesItem.tsx
@@ -38,6 +38,6 @@ export const OwnerReferencesItem: React.FC<OwnerReferencesProps> = ({ resource }
  * @typedef {Object} OwnerReferencesProps
  * @property {K8sResourceCommon} resource - The resource whose owner references will be displayed.
  */
-export type OwnerReferencesProps = {
+type OwnerReferencesProps = {
   resource: K8sResourceCommon;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/PageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/PageHeadings.tsx
@@ -56,7 +56,7 @@ export const PageHeadings: React.FC<PageHeadingsProps> = ({
   );
 };
 
-export interface PageHeadingsProps {
+interface PageHeadingsProps {
   model: K8sModel;
   namespace?: string;
   obj?: K8sResourceCommon;

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableIconCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableIconCell.tsx
@@ -23,6 +23,6 @@ export const TableIconCell: React.FC<TableIconCellProps> = ({
   );
 };
 
-export interface TableIconCellProps extends TableLabelCellProps {
+interface TableIconCellProps extends TableLabelCellProps {
   icon?: ReactNode;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
@@ -25,7 +25,7 @@ export const TableLinkCell: React.FC<TableLinkCellProps> = ({
   );
 };
 
-export interface TableLinkCellProps extends TableLabelCellProps {
+interface TableLinkCellProps extends TableLabelCellProps {
   groupVersionKind: K8sGroupVersionKind;
   name: string;
   namespace: string;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProviderSectionHeading.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProviderSectionHeading.tsx
@@ -27,7 +27,7 @@ export const EditProviderSectionHeading: React.FC<EditProviderSectionHeadingProp
   </>
 );
 
-export type EditProviderSectionHeadingProps = {
+type EditProviderSectionHeadingProps = {
   text: string;
   helpText?: string;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -11,7 +11,7 @@ import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
 import { Alert, Checkbox, Form, Popover, Radio, TextInput } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-export interface EsxiProviderCreateFormProps {
+interface EsxiProviderCreateFormProps {
   provider: V1beta1Provider;
   onChange: (newValue: V1beta1Provider) => void;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
@@ -6,7 +6,7 @@ import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
 import { Form, TextInput } from '@patternfly/react-core';
 
-export interface OVAProviderCreateFormProps {
+interface OVAProviderCreateFormProps {
   provider: V1beta1Provider;
   onChange: (newValue: V1beta1Provider) => void;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -6,7 +6,7 @@ import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
 import { Form, TextInput } from '@patternfly/react-core';
 
-export interface OpenshiftProviderCreateFormProps {
+interface OpenshiftProviderCreateFormProps {
   provider: V1beta1Provider;
   onChange: (newValue: V1beta1Provider) => void;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
@@ -6,7 +6,7 @@ import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
 import { Form, TextInput } from '@patternfly/react-core';
 
-export interface OpenstackProviderCreateFormProps {
+interface OpenstackProviderCreateFormProps {
   provider: V1beta1Provider;
   onChange: (newValue: V1beta1Provider) => void;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
@@ -6,7 +6,7 @@ import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
 import { Form, TextInput } from '@patternfly/react-core';
 
-export interface OvirtProviderCreateFormProps {
+interface OvirtProviderCreateFormProps {
   provider: V1beta1Provider;
   onChange: (newValue: V1beta1Provider) => void;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -12,7 +12,7 @@ import { V1beta1Provider } from '@kubev2v/types';
 import { Alert, Checkbox, Form, Popover, Radio, TextInput } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
-export interface VCenterProviderCreateFormProps {
+interface VCenterProviderCreateFormProps {
   provider: V1beta1Provider;
   caCert: string;
   onChange: (newValue: V1beta1Provider) => void;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/ConditionsSection/ConditionsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/ConditionsSection/ConditionsSection.tsx
@@ -72,6 +72,6 @@ export const ConditionsSection: React.FC<ConditionsProps> = ({ conditions }): Re
  * @typedef {Object} ConditionsProps
  * @property {K8sResourceCondition[]} conditions - The conditions to be displayed.
  */
-export type ConditionsProps = {
+type ConditionsProps = {
   conditions: K8sResourceCondition[];
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/CredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/CredentialsSection.tsx
@@ -120,7 +120,7 @@ export const CredentialsSection_: React.FC<{
   }
 };
 
-export type CredentialsProps = {
+type CredentialsProps = {
   data: ProviderData;
   loaded: boolean;
   loadError: unknown;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/EsxiCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/EsxiCredentialsSection.tsx
@@ -9,7 +9,7 @@ import {
 import { EsxiCredentialsEdit } from './components/edit/EsxiCredentialsEdit';
 import { EsxiCredentialsList } from './components/list';
 
-export type EsxiCredentialsSectionProps = Omit<
+type EsxiCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/FieldWithClipboardCopy.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/FieldWithClipboardCopy.tsx
@@ -5,7 +5,7 @@ import { ClipboardCopy, Switch, TextInput, Tooltip } from '@patternfly/react-cor
 
 import { Field } from './components/list/Fields';
 
-export interface ShowFieldWithClipboardCopyProps {
+interface ShowFieldWithClipboardCopyProps {
   value: string;
   field?: Field;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OpenshiftCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OpenshiftCredentialsSection.tsx
@@ -8,7 +8,7 @@ import {
 import { OpenshiftCredentialsEdit } from './components/edit/OpenshiftCredentialsEdit';
 import { OpenshiftCredentialsList } from './components/list/OpenshiftCredentialsList';
 
-export type OpenshiftCredentialsSectionProps = Omit<
+type OpenshiftCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OpenstackCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OpenstackCredentialsSection.tsx
@@ -8,7 +8,7 @@ import {
 import { OpenstackCredentialsEdit } from './components/edit/OpenstackCredentialsEdit';
 import { OpenstackCredentialsList } from './components/list/OpenstackCredentialsList';
 
-export type OpenstackCredentialsSectionProps = Omit<
+type OpenstackCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OvirtCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/OvirtCredentialsSection.tsx
@@ -8,7 +8,7 @@ import {
 import { OvirtCredentialsEdit } from './components/edit/OvirtCredentialsEdit';
 import { OvirtCredentialsList } from './components/list/OvirtCredentialsList';
 
-export type OvirtCredentialsSectionProps = Omit<
+type OvirtCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/VCenterCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/VCenterCredentialsSection.tsx
@@ -9,7 +9,7 @@ import {
 import { VCenterCredentialsEdit } from './components/edit/VCenterCredentialsEdit';
 import { VCenterCredentialsList } from './components/list/VCenterCredentialsList';
 
-export type VCenterCredentialsSectionProps = Omit<
+type VCenterCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/state/reducer.ts
@@ -23,7 +23,7 @@ export interface BaseCredentialsSectionState {
   alertMessage: ReactNode;
 }
 
-export type BaseCredentialsAction =
+type BaseCredentialsAction =
   | { type: 'TOGGLE_REVEAL' }
   | { type: 'TOGGLE_EDIT' }
   | { type: 'RESET_DATA_CHANGED' }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/ExternalManagementLinkDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/ExternalManagementLinkDetailsItem.tsx
@@ -15,7 +15,7 @@ import { ProviderDetailsItemProps } from './ProviderDetailsItem';
  * @property {string} [webUILinkText - A label text to be displayed as a content.
  * @property {string} [webUILink] - provider's management system external link.
  */
-export interface ExternalManagementLinkDetailsItemProps extends ProviderDetailsItemProps {
+interface ExternalManagementLinkDetailsItemProps extends ProviderDetailsItemProps {
   webUILinkText?: string;
   webUILink?: string;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/SecretsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/SecretsSection.tsx
@@ -20,6 +20,6 @@ export const SecretsSection: React.FC<SecretsSectionProps> = (props) => {
   );
 };
 
-export type SecretsSectionProps = {
+type SecretsSectionProps = {
   data: ProviderData;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/SecretDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/SecretDetailsItem.tsx
@@ -6,7 +6,7 @@ import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
 import { DetailsItem } from '../../../../../utils';
 
-export interface SecretDetailsItemProps {
+interface SecretDetailsItemProps {
   resource: V1beta1Provider;
   moreInfoLink?: string;
   helpContent?: ReactNode;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
@@ -23,7 +23,7 @@ import { calculateCidrNotation, InventoryHostPair, onSaveHost } from '../utils';
 
 import './VSphereNetworkModal.style.css';
 
-export interface VSphereNetworkModalProps {
+interface VSphereNetworkModalProps {
   provider: V1beta1Provider;
   data: InventoryHostPair[];
   selected: string[];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -19,7 +19,7 @@ import { Concern } from '@kubev2v/types';
 import { ConcernsTable } from './ConcernsTable';
 import { MigrationAction } from './MigrationAction';
 import { VmData } from './VMCellProps';
-export interface ProviderVirtualMachinesListProps {
+interface ProviderVirtualMachinesListProps {
   title?: string;
   obj: ProviderData;
   ns?: string;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
@@ -23,7 +23,7 @@ import { Mapping, MappingSource } from '../types';
 
 import '../ProvidersCreateVmMigration.style.css';
 
-export interface MappingListItemProps {
+interface MappingListItemProps {
   source: string;
   destination: string;
   destinations: string[];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
@@ -102,7 +102,7 @@ const buildStorageMessages = (
   },
 });
 
-export type PlansCreateFormProps = {
+type PlansCreateFormProps = {
   children?: ReactNode;
   formAlerts?: ReactNode;
   formActions?: ReactNode;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
@@ -105,7 +105,7 @@ export type SelectedVms = {
   sourceProvider: V1beta1Provider;
 };
 
-export interface PlanDescription {
+interface PlanDescription {
   description: string;
 }
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/actions/StorageMapActionsDropdown.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/actions/StorageMapActionsDropdown.tsx
@@ -72,6 +72,6 @@ export const StorageMapActionsDropdown: React.FC<StorageMapActionsDropdownProps>
   </ModalHOC>
 );
 
-export interface StorageMapActionsDropdownProps extends CellProps {
+interface StorageMapActionsDropdownProps extends CellProps {
   isKebab?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ConditionsSection/ConditionsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ConditionsSection/ConditionsSection.tsx
@@ -70,6 +70,6 @@ export const ConditionsSection: React.FC<ConditionsSectionProps> = ({ conditions
  * @typedef {Object} ConditionsProps
  * @property {K8sResourceCondition[]} conditions - The conditions to be displayed.
  */
-export type ConditionsSectionProps = {
+type ConditionsSectionProps = {
   conditions: K8sResourceCondition[];
 };

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/DetailsSection/DetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/DetailsSection/DetailsSection.tsx
@@ -17,7 +17,7 @@ export const DetailsSection: React.FC<DetailsSectionProps> = (props) => (
   </ModalHOC>
 );
 
-export type DetailsSectionProps = {
+type DetailsSectionProps = {
   obj: V1beta1StorageMap;
 };
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -203,7 +203,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
   );
 };
 
-export type MapsSectionProps = {
+type MapsSectionProps = {
   obj: V1beta1StorageMap;
 };
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/components/MapsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/components/MapsEdit.tsx
@@ -83,7 +83,7 @@ export const MapsEdit: React.FC<MapsEditProps> = ({
   }
 };
 
-export type MapsEditProps = {
+type MapsEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
   onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/state/reducer.ts
@@ -8,7 +8,7 @@ export interface MapsSectionState {
   updating: boolean;
 }
 
-export type MapsAction =
+type MapsAction =
   | { type: 'SET_MAP'; payload: V1beta1StorageMapSpecMap[] }
   | { type: 'SET_UPDATING'; payload: boolean }
   | { type: 'INIT'; payload: V1beta1StorageMap };

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -121,6 +121,6 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
   );
 };
 
-export type ProvidersSectionProps = {
+type ProvidersSectionProps = {
   obj: V1beta1StorageMap;
 };

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -82,7 +82,7 @@ export const ProvidersEdit: React.FC<ProvidersEditProps> = ({
   }
 };
 
-export type ProvidersEditProps = {
+type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
   onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/state/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/state/reducer.ts
@@ -10,7 +10,7 @@ export interface ProvidersSectionState {
   updating: boolean;
 }
 
-export type ProvidersAction =
+type ProvidersAction =
   | { type: 'SET_SOURCE_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_TARGET_PROVIDER'; payload: V1beta1Provider }
   | { type: 'SET_SOURCE_PROVIDER_MODE'; payload: 'view' | 'edit' }

--- a/packages/forklift-console-plugin/src/utils/constants.ts
+++ b/packages/forklift-console-plugin/src/utils/constants.ts
@@ -4,8 +4,7 @@ export enum Namespace {
   AllProjects = '#ALL_NS#',
   KonveyorForklift = 'konveyor-forklift',
   OpenshiftMtv = 'openshift-mtv',
-  Default = 'default',
-}
+  }
 
 export enum ServerBranding {
   Okd = 'okd',


### PR DESCRIPTION
## 📝 Links

Rebase and merge after https://github.com/jschuler/forklift-console-plugin/pull/1

Towards https://issues.redhat.com/browse/MTV-1988

## 📝 Description

Remove `export` from types that are not needed outside their own files

Note that I had to add `export` back to `packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getMigrationVmsCounts.ts` `MigrationVmsCounts` type since it is used in `packages/forklift-console-plugin/src/modules/Plans/views/list/components/VMsProgressCell.tsx`.

That file will be deleted in https://github.com/jschuler/forklift-console-plugin/pull/1, so after that is merged I will rebase this PR and remove the export from that type.

## 🎥 Demo

```
yarn knip --include types
```

